### PR TITLE
Leaks + error message + redirect

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -34,6 +34,7 @@ struct s_cmd {
 	char	**argv;
 	char	*cmd_path;
 	char	*not_parsed;
+	int		redirect_error;
 	int		pipe[2];
 	int		fd_in;
 	int		fd_out;
@@ -44,6 +45,8 @@ struct s_minishell {
 	t_var	*env_var;
 	t_var	*local_var;
 	t_cmd	*cmd_node;
+	int		total_cmd;
+	int		redirect_error;
 	char	**path;
 	int		count;
 	int		pipe[2];
@@ -54,6 +57,7 @@ struct s_minishell {
 
 //  SUPPORT
 void	ms_display_error(char *id, char *err, int should_quit);
+void	ms_display_error_execve(char *id, char *err, int should_quit);
 int		ft_next_occurrence(char *str, char y);
 void	*ft_free_double_pointer(char **pointer);
 void	ft_save_paths(void);
@@ -66,6 +70,7 @@ char	*ft_prompt(void);
 int		ft_save_history(char *prompt_line);
 void	ft_alloc_cmd(char *str);
 char	*get_next_line(int fd);
+void	*ft_free(void *pointer);
 
 // REDIRECT
 char	*ft_redirect(char *prompt_line);

--- a/src/builtins/ms_cd.c
+++ b/src/builtins/ms_cd.c
@@ -9,6 +9,8 @@ void	ms_cd(char **argv)
 	char	*oldpwd;
 	char	*hold_home_value;
 	int		operation_status;
+	char	*home1;
+	char	*home2;
 
 	operation_status = 0;
 	oldpwd = getcwd(NULL, 0);
@@ -16,20 +18,26 @@ void	ms_cd(char **argv)
 	{
 		ms_display_error("cd: ", "too many arguments", 0);
 		g_ms->exit_code = 1;
+		free (oldpwd);
 		return ;
 	}
 	else if (argv[1] == NULL || !ft_strncmp(argv[1], "~", -1))
 	{
+		home1 = ft_strdup("$HOME");
+		home2 = ft_strdup("$HOME");
 		operation_status = -1;
-		hold_home_value = ft_find(ft_strdup("$HOME"), ft_strdup("$HOME"));
+		hold_home_value = ft_find(home1, home2);
 		if (hold_home_value[0])
 			operation_status = chdir(hold_home_value);
 		free(hold_home_value);
+		free (home1);
+		free (home2);
 	}
 	else
 		operation_status = chdir(argv[1]);
 	act_according_to_status(operation_status, argv[1]);
-	update_pwd(ft_strdup(oldpwd));
+	update_pwd(oldpwd);
+	free (oldpwd);
 }
 
 static void	act_according_to_status(int status, char *dir)
@@ -45,15 +53,30 @@ static void	act_according_to_status(int status, char *dir)
 
 static void	cd_failed(char *dir)
 {
+	char* temp_join;
+
+	temp_join = ft_strjoin(dir, ": No such file or directory");
 	if (dir == NULL)
 		ms_display_error("cd: ", "HOME not set", 0);
 	else
-		ms_display_error("cd: ", ft_strjoin(dir,
-				": No such file or directory"), 0);
+		ms_display_error("cd: ", temp_join, 0);
+	free (temp_join);
+	return ;
 }
 
 static void	update_pwd(char *oldpwd)
 {
-	g_ms->env_var = add_vars_to_env(ft_strdup("OLDPWD"), oldpwd, g_ms->env_var);
-	g_ms->env_var = add_vars_to_env(ft_strdup("PWD"), ft_strdup(getcwd(NULL, 0)), g_ms->env_var);
+	char *OLD_PWD;
+	char *PWD;
+	char *GET_CDW;
+
+	OLD_PWD = ft_strdup("OLDPWD");
+	PWD = ft_strdup("PWD");
+	GET_CDW = getcwd(NULL, 0);
+	g_ms->env_var = add_vars_to_env(OLD_PWD, oldpwd, g_ms->env_var);
+	g_ms->env_var = add_vars_to_env(PWD, GET_CDW, g_ms->env_var);
+	free (OLD_PWD);
+	free (PWD);
+	free (GET_CDW);
+	return ;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -20,6 +20,7 @@ static void	repl(void)
 		}
 		ft_alloc_cmd(input);
 		ft_unpipe_and_alloc(input);
+		g_ms->total_cmd = g_ms->n_pipe + 1;
 		ft_parse();
 		ft_process_cmds();
 	}
@@ -43,3 +44,10 @@ int	main(int argc, char *argv[], char *envp[])
 	repl();
 	return (0);
 }
+
+
+// preciso colocar os erros dentro da estrutura e parar de executar os comandos caso tenha erro de permissão !
+// integrar heredoc
+// TESTES
+// as <1212 (fica em loop infinito, checar)
+// parse de apenas redirect da segfault

--- a/src/parse/parse.c
+++ b/src/parse/parse.c
@@ -33,25 +33,23 @@ void ft_parse (void)
 	int i;
 
 	g_ms->count = 0;
-	i = 0;
-	g_ms->n_cmd = g_ms->n_pipe + 1;
-	while (g_ms->n_cmd > i)
+	i = -1;
+	while (g_ms->total_cmd > ++i)
 	{
 		g_ms->cmd_node[i].not_parsed = ft_redirect(g_ms->cmd_node[i].not_parsed);
-		//chechar se tem erro no redirect (variavel :g_ms->cmd_node[i].error)
+		if (g_ms->redirect_error)
+		{
+			g_ms->exit_code = 1;
+			g_ms->cmd_node[i].redirect_error = 1;
+			g_ms->redirect_error = 0;
+			g_ms->count++;
+			continue;
+		}
 		ft_split_space(&g_ms->cmd_node[i]);
 		ft_expand_var_cmd_node (&g_ms->cmd_node[i]);
 		g_ms->cmd_node[i].argv = ft_save_env_vars (&g_ms->cmd_node[i]);
 		ft_remove_quotes_from_cmd_node (&g_ms->cmd_node[i]);
 		g_ms->count++;
-		i++;
 	}
 	return ;
-	//redirect (se erro, poe dentro do node e continue)
-	//expandir variáveis
-	//splitar comandos em space
-	//checar se é builtin, atribuição, execv ou se não existe o cmd
-	// se tiver atribuição fazer agora (se tiver mais de um cmd ou tiver pipe = atribuição temporária apenas)
-	//o que deve acontecer se o comando é apenas um diretorio para um arquivo ou pasta?
-
 }

--- a/src/parse/unpipe_and_alloc.c
+++ b/src/parse/unpipe_and_alloc.c
@@ -6,7 +6,9 @@ static void ft_alloc_in_cmd_node (char **str)
 
 	i = -1;
 	while (str[++i])
+	{
 		g_ms->cmd_node[i].not_parsed = ft_strdup(str[i]);
+	}
 	return ;
 }
 
@@ -27,10 +29,11 @@ static void ft_count_pipes (char *prompt_line)
 	i = -1;
 	while (prompt_line[++i])
 	{
-		if (prompt_line[i] == '|')
-			g_ms->n_pipe++;
-		else if (prompt_line[i] == '\'' || prompt_line[i] == '\"')
+
+		if (prompt_line[i] == '\'' || prompt_line[i] == '\"')
 			i += (ft_next_occurrence (&prompt_line[i], prompt_line[i]));
+		else if (prompt_line[i] == '|')
+			g_ms->n_pipe++;
 	}
 	return ;
 }

--- a/src/pipes/redirect.c
+++ b/src/pipes/redirect.c
@@ -84,12 +84,6 @@ char *ft_file_name (char *prompt_line, char redirect)
 		i++;
 	while (prompt_line[i] == ' ')
 		i++;
-	if (!prompt_line[i] || prompt_line[i] < 33 || prompt_line[i] > 126
-		|| prompt_line[i] == '>' || prompt_line[i] == '<')
-	{
-		printf ("erro redirect");
-		return (NULL);
-	}
 	if (prompt_line[i] == '\"' || prompt_line[i] == '\'')
 		file_name = ft_get_file_name (&prompt_line[i + 1], prompt_line[i]);
 	else
@@ -142,6 +136,8 @@ char *ft_redirect (char *prompt_line)
 		{
 			prompt_line = ft_check_redirect_type (prompt_line , &prompt_line[i], prompt_line[i]);
 			i = -1;
+			if (g_ms->redirect_error)
+				break;
 		}
 	}
 	return (prompt_line);

--- a/src/pipes/redirect_in.c
+++ b/src/pipes/redirect_in.c
@@ -9,13 +9,20 @@ static void ft_open_in (char *str, char *prompt_line)
 	{
 		if (access(file_name, R_OK) < 0)
 		{
-			printf ("nao tem acesso\n");
+
+			ms_display_error(file_name, ": Permission denied", 0);
+			free (file_name);
+			g_ms->redirect_error = 1;
 			return ;
 		}
 		g_ms->cmd_node[g_ms->count].fd_in = open (file_name, O_RDONLY);
 	}
 	else
-		printf ("arquivo não existe\n");
+	{
+		ms_display_error(file_name, ": No such file or directory", 0);
+		g_ms->redirect_error = 1;
+	}
+	free (file_name);
 	return ;
 }
 

--- a/src/pipes/redirect_out.c
+++ b/src/pipes/redirect_out.c
@@ -9,7 +9,9 @@ static void ft_open_out (char *str, char *prompt_line, int t)
 	{
 		if (access(file_name, W_OK) < 0)
 		{
-			printf ("nao pode escrever\n");
+			ms_display_error(file_name, ": Permission denied", 0);
+			free (file_name);
+			g_ms->redirect_error = 1;
 			return ;
 		}
 		if (t == 1)
@@ -19,6 +21,7 @@ static void ft_open_out (char *str, char *prompt_line, int t)
 	}
 	else
 		g_ms->cmd_node[g_ms->count].fd_out =  open (file_name, O_RDWR | O_CREAT | O_APPEND, 0644);
+	free (file_name);
 	return ;
 }
 

--- a/src/process/check_exec.c
+++ b/src/process/check_exec.c
@@ -1,6 +1,5 @@
 #include "minishell.h"
 
-
 static int ft_absoluth_path_check (t_cmd *cmd)
 {
 	struct stat	type;
@@ -21,6 +20,7 @@ static int	ft_check_access(t_cmd *cmd)
 	struct stat	type;
 
 	i = -1;
+	ft_free_double_pointer(g_ms->path);
 	cmd->cmd_path = 0;
 	if (!ft_absoluth_path_check(cmd))
 		return (0);
@@ -29,11 +29,17 @@ static int	ft_check_access(t_cmd *cmd)
 	{
 		cmd->cmd_path = ft_strjoin(g_ms->path[i], cmd->argv[0]);
 		if (stat (cmd->cmd_path, &type))
+		{
+			free (cmd->cmd_path);
+			cmd->cmd_path = NULL;
 			continue;
+
+		}
 		if ((type.st_mode & S_IXUSR))
 			return (0);
 		free (cmd->cmd_path);
 		cmd->cmd_path = NULL;
+
 	}
 	return (1);
 }
@@ -41,7 +47,11 @@ static int	ft_check_access(t_cmd *cmd)
 static void ft_exec_cmd (t_cmd *cmd)
 {
 	if (execve (cmd->cmd_path, cmd->argv, g_ms->path))
-		write (2, "Error\n", 7);
+	{
+		write (2, "Error at execve\n", 17);
+		free_all_struct (0);
+	}
+	return ;
 }
 
 static void ft_create_process (t_cmd *cmd)
@@ -66,6 +76,9 @@ void ft_check_exec (t_cmd *cmd)
 	if (!ft_check_access(cmd))
 		ft_create_process (cmd);
 	else
-		printf ("Erro check path FT_CHECK_EXEC\n");
+	{
+		ms_display_error_execve(cmd->argv[0],": command not found", 0);
+		g_ms->exit_code = 127;
+	}
 	return ;
 }

--- a/src/process/start_process.c
+++ b/src/process/start_process.c
@@ -27,10 +27,13 @@ void	ft_process_cmds (void)
 	while (g_ms->count--)
 	{
 		ft_open_pipe (&g_ms->cmd_node[i]);
-		if (is_builtin (&g_ms->cmd_node[i]))
-			exec_builtin(&g_ms->cmd_node[i]);
-		else
-		 	ft_check_exec (&g_ms->cmd_node[i]);
+		if (g_ms->cmd_node[i].redirect_error == 0)
+		{
+			if (is_builtin (&g_ms->cmd_node[i]))
+				exec_builtin(&g_ms->cmd_node[i]);
+			else
+		 		ft_check_exec (&g_ms->cmd_node[i]);
+		}
 		if (g_ms->n_cmd)
 			close (g_ms->cmd_node[i - 1].pipe[0]);
 		close (g_ms->cmd_node[i].pipe[1]);

--- a/src/utils/free_functions.c
+++ b/src/utils/free_functions.c
@@ -1,6 +1,6 @@
 #include "minishell.h"
 
-static void	*ft_free(void *pointer)
+void	*ft_free(void *pointer)
 {
 	if (pointer)
 		free(pointer);
@@ -44,7 +44,7 @@ static void	free_cmd_nodes(void)
 	int	i;
 
 	i = 0;
-	while (g_ms->n_pipe > i + 1)
+	while (g_ms->total_cmd > i)
 	{
 		ft_free_double_pointer(g_ms->cmd_node[i].argv);
 		ft_free(g_ms->cmd_node[i].cmd_path);

--- a/src/utils/ms_display_error.c
+++ b/src/utils/ms_display_error.c
@@ -6,7 +6,17 @@ void	ms_display_error(char *id, char *err, int should_quit)
 	ft_putstr_fd(id, STDERR_FILENO);
 	ft_putendl_fd(err, STDERR_FILENO);
 	if (should_quit) {
-		// cleanup eveything()
+		free_all_struct (1);
+		exit(g_ms->exit_code);
+	}
+}
+
+void	ms_display_error_execve(char *id, char *err, int should_quit)
+{
+	ft_putstr_fd(id, STDERR_FILENO);
+	ft_putendl_fd(err, STDERR_FILENO);
+	if (should_quit) {
+		free_all_struct (1);
 		exit(g_ms->exit_code);
 	}
 }


### PR DESCRIPTION
-leaks inside builtisn and execve are gone

-now we display the correct error messages + the right exit code

- redirects have the right behavior when the access function can't open or read the file